### PR TITLE
Add support for Linux (expedite from #3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# Directories
+.vs/
+bin/
+bin-int/
+
+# Files
+*.user
+Makefile

--- a/premake5.lua
+++ b/premake5.lua
@@ -1,34 +1,34 @@
 project "ImGui"
-    kind "StaticLib"
-    language "C++"
+	kind "StaticLib"
+	language "C++"
 
-    targetdir ("bin/" .. outputdir .. "/%{prj.name}")
-    objdir ("bin-int/" .. outputdir .. "/%{prj.name}")
+	targetdir ("bin/" .. outputdir .. "/%{prj.name}")
+	objdir ("bin-int/" .. outputdir .. "/%{prj.name}")
 
-    files
-    {
-        "imconfig.h",
-        "imgui.h",
-        "imgui.cpp",
-        "imgui_draw.cpp",
-        "imgui_internal.h",
-        "imgui_widgets.cpp",
-        "imstb_rectpack.h",
-        "imstb_textedit.h",
-        "imstb_truetype.h",
-        "imgui_demo.cpp"
-    }
+	files
+	{
+		"imconfig.h",
+		"imgui.h",
+		"imgui.cpp",
+		"imgui_draw.cpp",
+		"imgui_internal.h",
+		"imgui_widgets.cpp",
+		"imstb_rectpack.h",
+		"imstb_textedit.h",
+		"imstb_truetype.h",
+		"imgui_demo.cpp"
+	}
 
-    filter "system:windows"
-        systemversion "latest"
-        cppdialect "C++17"
-        staticruntime "On"
+	filter "system:windows"
+		systemversion "latest"
+		cppdialect "C++17"
+		staticruntime "On"
 
-    filter "system:linux"
-        systemversion "latest"
-        cppdialect "C++17"
-        staticruntime "On"
-        pic "On"
+	filter "system:linux"
+		pic "On"
+		systemversion "latest"
+		cppdialect "C++17"
+		staticruntime "On"
 
-    filter { "system:windows", "configurations:Release" }
-        buildoptions "/MT"
+	filter { "system:windows", "configurations:Release" }
+		buildoptions "/MT"

--- a/premake5.lua
+++ b/premake5.lua
@@ -30,5 +30,10 @@ project "ImGui"
 		cppdialect "C++17"
 		staticruntime "On"
 
-	filter { "system:windows", "configurations:Release" }
-		buildoptions "/MT"
+	filter "configurations:Debug"
+		runtime "Debug"
+		symbols "on"
+
+	filter "configurations:Release"
+		runtime "Release"
+		optimize "on"

--- a/premake5.lua
+++ b/premake5.lua
@@ -1,12 +1,12 @@
 project "ImGui"
     kind "StaticLib"
     language "C++"
-    
-	targetdir ("bin/" .. outputdir .. "/%{prj.name}")
+
+    targetdir ("bin/" .. outputdir .. "/%{prj.name}")
     objdir ("bin-int/" .. outputdir .. "/%{prj.name}")
 
-	files
-	{
+    files
+    {
         "imconfig.h",
         "imgui.h",
         "imgui.cpp",
@@ -18,11 +18,17 @@ project "ImGui"
         "imstb_truetype.h",
         "imgui_demo.cpp"
     }
-    
-	filter "system:windows"
+
+    filter "system:windows"
         systemversion "latest"
         cppdialect "C++17"
         staticruntime "On"
-        
+
+    filter "system:linux"
+        systemversion "latest"
+        cppdialect "C++17"
+        staticruntime "On"
+        pic "On"
+
     filter { "system:windows", "configurations:Release" }
         buildoptions "/MT"


### PR DESCRIPTION
Same PR as #3, but without any need for @cubedtear to merge my PR request.

This PR contains:
- Add bin and bin-int to .gitignore
- Convert the mix of tabs and spaces to all tabs
- Implements configuration settings (as seen in [video about building as static lib](https://www.youtube.com/watch?v=TlvmnoDlrI0&list=PLlrATfBNZ98dC-V-N3m0Go4deliWHPFwT&index=26))
- **Add support for linux as done in #3**

Merging this PR also:
- closes #3 that is not updated anymore that required cubedtear/imgui#1 to be merged
  - closes cubedtear/imgui#1

_This PR is part of TheCherno/Hazel#27 to add linux support to Hazel_

Kind regards
lovely_santa