### PR TITLE
Include the imgui files which provide support for std::strings in premake5.lua

### DIFF
--- a/misc/cpp/imgui_stdlib.cpp
+++ b/misc/cpp/imgui_stdlib.cpp
@@ -8,7 +8,7 @@
 // Changelog:
 // - v0.10: Initial version. Added InputText() / InputTextMultiline() calls with std::string
 
-#include "imgui.h"
+#include "../../imgui.h"
 #include "imgui_stdlib.h"
 
 struct InputTextCallback_UserData

--- a/premake5.lua
+++ b/premake5.lua
@@ -17,8 +17,8 @@ project "ImGui"
 		"imstb_textedit.h",
 		"imstb_truetype.h",
 		"imgui_demo.cpp",
-        "misc/cpp/imgui_stdlib.cpp",
-        "misc/cpp/imgui_stdlib.h"
+		"misc/cpp/imgui_stdlib.cpp",
+		"misc/cpp/imgui_stdlib.h"
 	}
 
 	filter "system:windows"

--- a/premake5.lua
+++ b/premake5.lua
@@ -16,7 +16,9 @@ project "ImGui"
 		"imstb_rectpack.h",
 		"imstb_textedit.h",
 		"imstb_truetype.h",
-		"imgui_demo.cpp"
+		"imgui_demo.cpp",
+        "misc/cpp/imgui_stdlib.cpp",
+        "misc/cpp/imgui_stdlib.h"
 	}
 
 	filter "system:windows"


### PR DESCRIPTION
This PR was made for an issue created in the hazel repository.
That issue can be found here https://github.com/TheCherno/Hazel/issues/382