### PR TITLE
Fix for ImGui::SetActiveID in imgui.cpp

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -3836,9 +3836,9 @@ void ImGui::SetActiveID(ImGuiID id, ImGuiWindow* window)
     ImGuiContext& g = *GImGui;
 
 
-    for (int i = 0; i < DC.Layouts.Data.Size; i++)
+    for (int i = 0; i < window->DC.Layouts.Data.Size; i++)
     {
-        ImGuiLayout* layout = (ImGuiLayout*)DC.Layouts.Data[i].val_p;
+        ImGuiLayout* layout = (ImGuiLayout*)window->DC.Layouts.Data[i].val_p;
         IM_DELETE(layout);
     }
     // While most behaved code would make an effort to not steal active id during window move/drag operations,

--- a/imgui.cpp
+++ b/imgui.cpp
@@ -3835,12 +3835,15 @@ void ImGui::SetActiveID(ImGuiID id, ImGuiWindow* window)
 {
     ImGuiContext& g = *GImGui;
 
-
-    for (int i = 0; i < window->DC.Layouts.Data.Size; i++)
+    if (window != NULL)
     {
-        ImGuiLayout* layout = (ImGuiLayout*)window->DC.Layouts.Data[i].val_p;
-        IM_DELETE(layout);
+        for (int i = 0; i < window->DC.Layouts.Data.Size; i++)
+        {
+            ImGuiLayout* layout = (ImGuiLayout*)window->DC.Layouts.Data[i].val_p;
+            IM_DELETE(layout);
+        }
     }
+
     // While most behaved code would make an effort to not steal active id during window move/drag operations,
     // we at least need to be resilient to it. Cancelling the move is rather aggressive and users of 'master' branch
     // may prefer the weird ill-defined half working situation ('docking' did assert), so may need to rework that.

--- a/premake5.lua
+++ b/premake5.lua
@@ -1,7 +1,7 @@
 project "ImGui"
 	kind "StaticLib"
 	language "C++"
-    staticruntime "off"
+    staticruntime "on"
 
 	targetdir ("bin/" .. outputdir .. "/%{prj.name}")
 	objdir ("bin-int/" .. outputdir .. "/%{prj.name}")

--- a/premake5.lua
+++ b/premake5.lua
@@ -1,6 +1,7 @@
 project "ImGui"
 	kind "StaticLib"
 	language "C++"
+	cppdialect "C++17"
     staticruntime "on"
 
 	targetdir ("bin/" .. outputdir .. "/%{prj.name}")
@@ -23,12 +24,10 @@ project "ImGui"
 
 	filter "system:windows"
 		systemversion "latest"
-		cppdialect "C++17"
 
 	filter "system:linux"
 		pic "On"
 		systemversion "latest"
-		cppdialect "C++17"
 
 	filter "configurations:Debug"
 		runtime "Debug"


### PR DESCRIPTION
There is a typo in the ImGui::SetActiveID function in [imgui.cpp]() between line 3834 and 3843

Also, the For Loop will produce an error when the ImGui::SetActiveID function is called with a NULL value for the window argument like on line 3893 in the ImGui::ClearActiveID function.