### PR TITLE
Fixed 'DC': undeclared identifier error

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -3836,9 +3836,9 @@ void ImGui::SetActiveID(ImGuiID id, ImGuiWindow* window)
     ImGuiContext& g = *GImGui;
 
 
-    for (int i = 0; i < DC.Layouts.Data.Size; i++)
+    for (int i = 0; i < window->DC.Layouts.Data.Size; i++)
     {
-        ImGuiLayout* layout = (ImGuiLayout*)DC.Layouts.Data[i].val_p;
+        ImGuiLayout* layout = (ImGuiLayout*)window->DC.Layouts.Data[i].val_p;
         IM_DELETE(layout);
     }
     // While most behaved code would make an effort to not steal active id during window move/drag operations,

--- a/imgui.cpp
+++ b/imgui.cpp
@@ -3835,11 +3835,12 @@ void ImGui::SetActiveID(ImGuiID id, ImGuiWindow* window)
 {
     ImGuiContext& g = *GImGui;
 
-
-    for (int i = 0; i < window->DC.Layouts.Data.Size; i++)
-    {
-        ImGuiLayout* layout = (ImGuiLayout*)window->DC.Layouts.Data[i].val_p;
-        IM_DELETE(layout);
+    if (window != nullptr) {
+        for (int i = 0; i < window->DC.Layouts.Data.Size; i++)
+        {
+            ImGuiLayout* layout = (ImGuiLayout*)window->DC.Layouts.Data[i].val_p;
+            IM_DELETE(layout);
+        }
     }
     // While most behaved code would make an effort to not steal active id during window move/drag operations,
     // we at least need to be resilient to it. Cancelling the move is rather aggressive and users of 'master' branch


### PR DESCRIPTION
I've been trying to fix this "'DC': undeclared identifier" error and I finally was able to fix it.

I noticed in the lines 3839 and 3841, the DC.Layouts calls were not being used correctly.